### PR TITLE
Add top-level build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -65,6 +65,7 @@
      <property name="tkdir" value="${basedir}"/>
      <echo message="Tookit to SPLDOC: ${tkdir}"/>
      <exec executable="${streams.install}/bin/spl-make-doc">
+        <arg value="--include-composite-operator-diagram"/>
         <arg value="--directory"/>
         <arg value="${tkdir}"/>
      </exec>


### PR DESCRIPTION
Add a top-level build.xml that builds the toolkit, indexes the samples toolkit and builds the SPLDOC for toolkit and the samples.

Have been using it as the target for a Jenkins continuous integration build server, using the ant targets "clean all spldoc"
