### PR TITLE
localFilename fix for FTPPut;consistent cut error message for InetSource

### DIFF
--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPPutFile/FTPPutFile.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPPutFile/FTPPutFile.xml
@@ -192,7 +192,7 @@ In case of sftp the path is always an absolute path.
       </parameter>
       <parameter>
         <name>localFilename</name>
-        <description>The name of the file to be transferred in the local file system.</description>
+        <description>The name of the file to be transferred in the local file system.  If relative, the path is relative to the data directory.</description>
         <optional>false</optional>
         <rewriteAllowed>true</rewriteAllowed>
         <expressionMode>Expression</expressionMode>

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPPutFile/FTPPutFile_cpp.cgt
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPPutFile/FTPPutFile_cpp.cgt
@@ -204,8 +204,14 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
 				writer->setPassword(<%=$password%>);
 <%			} %>
 <%		} %>
-
-		writer->setLocalFilename(<%=$localFilename%>);
+		const rstring localFilename(<%=$localFilename%>);
+		
+		if (localFilename[0] == '/') {
+		   writer->setLocalFilename(localFilename);
+		}
+		else {
+		     writer->setLocalFilename(Functions::Utility::dataDirectory()+"/"+<%=$localFilename%>);
+		}
 		writer->setHost(<%=$host%>);
 		writer->setPath(<%=$path%>);
 <%		if ($filename) {%>

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
@@ -7,7 +7,7 @@
 <%
   my $ccContext = $model->getContext()->getOptionalContext("ConsistentRegion");
   if (defined $ccContext) {
-    SPL::CodeGen::exitln("ERROR: The following operator is not supported in a consistent region: InetSource.);
+    SPL::CodeGen::exitln("ERROR: The following operator is not supported in a consistent region: InetSource.");
   }
 
   my $oport = $model->getOutputPortAt(0);

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
@@ -5,6 +5,11 @@
 <%SPL::CodeGen::implementationPrologue($model);%>
 
 <%
+  my $ccContext = $model->getContext()->getOptionalContext("ConsistentRegion");
+  if (defined $ccContext) {
+    SPL::CodeGen::exitln("InetSource operator is not allowed in a consistent region");
+  }
+
   my $oport = $model->getOutputPortAt(0);
   my $oportAttr = $oport->getAttributeAt(0);
   my $oportSPLType = $oportAttr->getSPLType();

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
@@ -7,7 +7,7 @@
 <%
   my $ccContext = $model->getContext()->getOptionalContext("ConsistentRegion");
   if (defined $ccContext) {
-    SPL::CodeGen::exitln("InetSource operator is not allowed in a consistent region");
+    SPL::CodeGen::exitln("ERROR: The following operator is not supported in a consistent region: InetSource.);
   }
 
   my $oport = $model->getOutputPortAt(0);

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetSource_cpp.cgt
@@ -7,7 +7,7 @@
 <%
   my $ccContext = $model->getContext()->getOptionalContext("ConsistentRegion");
   if (defined $ccContext) {
-    SPL::CodeGen::exitln("ERROR: The following operator is not supported in a consistent region: InetSource.");
+    SPL::CodeGen::exitln("The following operator is not supported in a consistent region: InetSource.");
   }
 
   my $oport = $model->getOutputPortAt(0);


### PR DESCRIPTION
This pull has two commits.  
* the localfilename fix for FTPPut @joergboe  -- can you get this branch and test that it works as expected?  It should work as before.
* InetSource gives an error mesage if used in a consistent region.

I'll leave this request open for at least a day to allow comments.