### PR TITLE
Support HTTPS in the Jetty operators

### DIFF
--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.rest/namespace-info.spl
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.rest/namespace-info.spl
@@ -53,6 +53,40 @@
  * * *JSON Data* - Link that provides the raw JSON data.
  * This tables use the Dojo Javascript library from the Steams install, and thus do
  * not require external internet connectivity.
+ *
+ * + HTTPS Support
+ * Overview of HTTP and HTTPS support for
+ * `com.ibm.streamsx.inet.rest` operators.
+ * # HTTP Support
+ * By default the REST operators provide open ports with no authentication
+ * or encryption. This mode is useful for development, testing, proof-of-concept
+ * applications and demonstrations. The only configuration is
+ * the port number for the HTTP server, which defaults to 8080.
+ * # HTTPS Support
+ * HTTPS (SSL/TLS encryption) is supported for all of the operators in
+ * `com.ibm.streamsx.inet.rest`. To use HTTPS, the operators are
+ * configured to use a certificate from a Java key store. Specifying a
+ * certificate enables HTTPS, using TLSv1.2, TLSv1.1 or TLSv1.0.
+ * A certificate is specified using these parameters:
+ * * `keyStore` - URL to the key store containing the certificate. If a relative file path then it is taken as relative to the application directory.
+ * * `keyStorePassword` - Password to the key store.
+ * * `certificateAlias` - Alias of the certificate to use in the key store.
+ * * `keyPassword` - Password to the certificate. If not provided, defaults to the value of `keyStorePassword`.
+ *
+ * All password parameters accept the Jetty obfuscated password style,
+ * which provides protection from casual viewing only. If the password
+ * values starts with `OBF:` then it is assumed to be already obfuscated,
+ * otherwise it is obfuscated before being passed to Jetty. The
+ * Jetty utility `org.eclipse.jetty.util.security.Password` may be
+ * used to obfuscate passwords, for example when passing them as
+ * submission time values. In addition the SPL function [obfuscate(T)]
+ * is provided as an option to obfuscate values.
+ *
+ * The port number can be specified, and defaults to 8080.
+ *
+ * Note that a single Jetty instance (potentially shared by multiple
+ * operators) either uses HTTPS or HTTP, not both.
+ *
 */
 
 namespace com.ibm.streamsx.inet.rest;

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.rest/namespace-info.spl
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.rest/namespace-info.spl
@@ -43,7 +43,7 @@
  * * `streamsx.inet.dojo` The Dojo Javascript library located at `$STREAMS_INSTALL/ext/dojo`. 
  * 
  * [HTTPTupleView] provides automatic visualization of tuples on its input ports.
- * These are available through the URL `streamsx.ient.resources/dojo/viewall.html`.
+ * These are available through the URL `streamsx.inet.resources/dojo/viewall.html`.
  * 
  * This provides a table containing links for all the ports connected to all HTTPTupleView
  * operators using the same Jetty webserver: The columns in the table are:

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/engine/ServletEngine.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/engine/ServletEngine.java
@@ -30,8 +30,10 @@ import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.server.ssl.SslSelectChannelConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
 
@@ -39,6 +41,7 @@ import com.ibm.streams.operator.OperatorContext;
 import com.ibm.streams.operator.StreamingData;
 import com.ibm.streamsx.inet.http.PathConversionHelper;
 import com.ibm.streamsx.inet.rest.ops.PostTuple;
+import com.ibm.streamsx.inet.rest.ops.Functions;
 import com.ibm.streamsx.inet.rest.servlets.ExposedPortsInfo;
 import com.ibm.streamsx.inet.rest.servlets.PortInfo;
 import com.ibm.streamsx.inet.rest.setup.ExposedPort;
@@ -61,6 +64,11 @@ public class ServletEngine implements ServletEngineMBean {
 
 	public static final String CONTEXT_RESOURCE_BASE_PARAM = "contextResourceBase";
     public static final String CONTEXT_PARAM = "context";
+    
+    public static final String SSL_CERT_ALIAS_PARAM = "certificateAlias";
+    public static final String SSL_KEYSTORE_PARAM = "keyStore";
+    public static final String SSL_KEYSTORE_PASSWORD_PARAM = "keyStorePassword";
+    public static final String SSL_KEY_PASSWORD_PARAM = "keyPassword";
 
     public static ServletEngineMBean getServletEngine(OperatorContext context) throws Exception {
 		
@@ -93,6 +101,7 @@ public class ServletEngine implements ServletEngineMBean {
 	private boolean stopped;
     
     private final Server server;
+    private boolean isSSL;
     private final ContextHandlerCollection handlers;
     private final Map<String, ServletContextHandler> contexts = Collections.synchronizedMap(
             new HashMap<String, ServletContextHandler>());
@@ -106,11 +115,11 @@ public class ServletEngine implements ServletEngineMBean {
        
         server = new Server();
         handlers = new ContextHandlerCollection();
-
-        SelectChannelConnector connector0 = new SelectChannelConnector();
-        connector0.setPort(portNumber);
-        connector0.setMaxIdleTime(30000);
-        server.addConnector(connector0);
+        
+        if (context.getParameterNames().contains(SSL_CERT_ALIAS_PARAM))
+            setHTTPSConnector(context, server, portNumber);
+        else
+            setHTTPConnector(context, server, portNumber);
         
         server.setThreadPool(new ThreadPool() {
 
@@ -165,6 +174,52 @@ public class ServletEngine implements ServletEngineMBean {
             File dojo = new File(streamsInstall, "ext/dojo");        
             addStaticContext(null, "streamsx.inet.dojo", dojo.getAbsolutePath());       	
         }
+    }
+    
+    /**
+     * Setup an HTTP connector.
+     */
+    private void setHTTPConnector(OperatorContext context, Server server, int portNumber) {
+        SelectChannelConnector connector = new SelectChannelConnector();
+        connector.setPort(portNumber);
+        connector.setMaxIdleTime(30000);
+        server.addConnector(connector);
+    }
+    
+    /**
+     * Setup an HTTPS connector.
+     */
+    private void setHTTPSConnector(OperatorContext context, Server server, int portNumber) {
+        SslContextFactory sslContextFactory = new SslContextFactory();
+        
+        String keyStorePath = context.getParameterValues(SSL_KEYSTORE_PARAM).get(0);
+        File keyStorePathFile = new File(keyStorePath);
+        if (!keyStorePathFile.isAbsolute())
+            keyStorePathFile = new File(context.getPE().getApplicationDirectory(), keyStorePath);
+        sslContextFactory.setKeyStorePath(keyStorePathFile.getAbsolutePath());
+        
+        String keyStorePassword = context.getParameterValues(SSL_KEYSTORE_PASSWORD_PARAM).get(0);
+        sslContextFactory.setKeyStorePassword(Functions.obfuscate(keyStorePassword));
+        
+        String keyPassword;
+        if (context.getParameterNames().contains(SSL_KEY_PASSWORD_PARAM))
+            keyPassword = context.getParameterValues(SSL_KEY_PASSWORD_PARAM).get(0);
+        else
+            keyPassword = keyStorePassword;
+   
+        sslContextFactory.setKeyManagerPassword(Functions.obfuscate(keyPassword));
+               
+        sslContextFactory.setAllowRenegotiate(false);
+        sslContextFactory.setIncludeProtocols("TLSv1.2", "TLSv1.1");
+        sslContextFactory.setExcludeProtocols("SSLv3");
+        
+        SslSelectChannelConnector connector = new SslSelectChannelConnector(sslContextFactory);
+        
+        connector.setPort(portNumber);
+        connector.setMaxIdleTime(30000);
+        server.addConnector(connector); 
+        
+        isSSL = true;
     }
     
 	private ThreadPoolExecutor newContextThreadPoolExecutor(OperatorContext context) {

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/Functions.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/Functions.java
@@ -1,0 +1,22 @@
+package com.ibm.streamsx.inet.rest.ops;
+
+import org.eclipse.jetty.util.security.Password;
+
+import com.ibm.streams.function.model.Function;
+
+public class Functions {
+    
+    @Function(description="Obfuscate a password for an operator in this namespace."
+            + "If the password is starts with `OBF:` then it is assumed to be "
+            + "already obfuscated and input is returned unchanged. This allows"
+            + "external tools to pass submission time values that are already "
+            + "obfuscated. The Eclipse Jetty class `org.eclipse.jetty.util.security.Password` "
+            + "is the underlying utility.")
+    
+    public static String obfuscate(String password) {
+        if (password.startsWith(Password.__OBFUSCATE))
+            return password;
+
+        return Password.obfuscate(password);
+    }
+}

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/PostJSON.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/PostJSON.java
@@ -10,10 +10,10 @@ import com.ibm.streams.operator.StreamSchema;
 import com.ibm.streams.operator.StreamingOutput;
 import com.ibm.streams.operator.Type.MetaType;
 import com.ibm.streams.operator.compile.OperatorContextChecker;
+import com.ibm.streams.operator.model.Icons;
 import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.Icons;
 
 @PrimitiveOperator(name="HTTPJSONInjection", description=PostJSON.DESC)
 @OutputPorts({@OutputPortSet(cardinality=1,
@@ -46,7 +46,7 @@ public class PostJSON extends ServletOperator {
 	}
 	
 	static final String DESC =
-			"Embeds a Jetty web server to allow HTTP POST requests with mime type `application/json` to submit a tuple on " + 
+			"Embeds a Jetty web server to allow HTTP or HTTPS POST requests with mime type `application/json` to submit a tuple on " + 
 			"its output ports. Each output port corresponds to a unique URL comprising the operator name " + 
 			"and the port index.\\n" + 
 			"\\n" + 
@@ -64,5 +64,5 @@ public class PostJSON extends ServletOperator {
 			"\\n" +
 			"**Limitations**:\\n" + 
 			"* Error handling is limited, incorrect URLs can crash the application.\\n" + 
-			"* No security access is provided to the data. This is mainly aimed at demos.";
+			"* By default no security access is provided to the data, HTTPS must be explicitly configured.";
 }

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/PostTuple.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/PostTuple.java
@@ -19,7 +19,7 @@ import com.ibm.streams.operator.model.PrimitiveOperator;
 public class PostTuple extends ServletOperator {
 	
 	static final String DESC =
-			"Embeds a Jetty web server to allow HTTP POST requests to submit a tuple on " + 
+			"Embeds a Jetty web server to allow HTTP or HTTPS POST requests to submit a tuple on " + 
 			"its output ports. Each output port corresponds to a unique URL comprising the operator name " + 
 			"and the port index.\\n" + 
 			"\\n" + 
@@ -51,7 +51,7 @@ public class PostTuple extends ServletOperator {
 			"* Error handling is limited, incorrect URLs can crash the application.\\n" + 
 			"* Not all SPL data types are supported. String, signed integer and float types are supported for POST parameters. Output port may contain other types but will be set\\n" + 
 			"to their default values.\\n" + 
-			"* No security access is provided to the data. This is mainly aimed at demos.";
+			"* By default no security access is provided to the data, HTTPS must be explicitly configured.";
 	
 	
 	public static final String MAX_CONTEXT_SIZE_DESC =

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/PostXML.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/PostXML.java
@@ -9,10 +9,10 @@ import com.ibm.streams.operator.OperatorContext.ContextCheck;
 import com.ibm.streams.operator.StreamingOutput;
 import com.ibm.streams.operator.Type.MetaType;
 import com.ibm.streams.operator.compile.OperatorContextChecker;
+import com.ibm.streams.operator.model.Icons;
 import com.ibm.streams.operator.model.OutputPortSet;
 import com.ibm.streams.operator.model.OutputPorts;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.Icons;
 
 @PrimitiveOperator(name="HTTPXMLInjection", description=PostXML.DESC)
 @OutputPorts({@OutputPortSet(cardinality=1,
@@ -35,7 +35,7 @@ public class PostXML extends ServletOperator {
 	}
 	
 	static final String DESC =
-			"Embeds a Jetty web server to allow HTTP POST requests to submit a tuple on " + 
+			"Embeds a Jetty web server to allow HTTP or HTTPS POST requests to submit a tuple on " + 
 			"its output ports. Each output port corresponds to a unique URL comprising the operator name " + 
 			"and the port index.\\n" + 
 			"\\n" + 
@@ -52,5 +52,5 @@ public class PostXML extends ServletOperator {
 			"\\n" + 
 			"**Limitations**:\\n" + 
 			"* Error handling is limited, incorrect URLs can crash the application.\\n" + 
-			"* No security access is provided to the data. This is mainly aimed at demos.";
+			"* By default no security access is provided to the data, HTTPS must be explicitly configured.";
 }

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/ServletOperator.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/ServletOperator.java
@@ -68,13 +68,14 @@ public abstract class ServletOperator extends AbstractOperator {
 	@Parameter(optional=true, description=CRB_DESC)
 	public void setContextResourceBase(String base) {}
 	
-	@Parameter(optional=true)
+	@Parameter(optional=true, description="Alias of the certificate to use in the key store.")
 	public void setCertificateAlias(String ca) {}
-	@Parameter(optional=true)
+	@Parameter(optional=true, description="URL to the key store containing the certificate. "
+	        + "If a relative file path then it is taken as relative to the application directory.")
 	public void setKeyStore(String ks) {}
-	@Parameter(optional=true)
+	@Parameter(optional=true, description="Password to the key store.")
 	public void setKeyStorePassword(String ksp) {}
-	@Parameter(optional=true)
+	@Parameter(optional=true, description="Password to the certificate. If not provided, defaults to the value of `keyStorePassword`.")
 	public void setKeyPassword(String kp) {}
 	
 	@ContextCheck

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/ServletOperator.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/ServletOperator.java
@@ -68,10 +68,27 @@ public abstract class ServletOperator extends AbstractOperator {
 	@Parameter(optional=true, description=CRB_DESC)
 	public void setContextResourceBase(String base) {}
 	
+	@Parameter(optional=true)
+	public void setCertificateAlias(String ca) {}
+	@Parameter(optional=true)
+	public void setKeyStore(String ks) {}
+	@Parameter(optional=true)
+	public void setKeyStorePassword(String ksp) {}
+	@Parameter(optional=true)
+	public void setKeyPassword(String kp) {}
+	
 	@ContextCheck
 	public static void checkContextParameters(OperatorContextChecker checker) {	
 		checker.checkDependentParameters("context", "contextResourceBase");
 		checker.checkDependentParameters("contextResourceBase", "context");
+		
+		checker.checkDependentParameters(ServletEngine.SSL_CERT_ALIAS_PARAM,
+		        ServletEngine.SSL_KEYSTORE_PARAM,
+		        ServletEngine.SSL_KEYSTORE_PASSWORD_PARAM);
+		
+		checker.checkDependentParameters(ServletEngine.SSL_KEY_PASSWORD_PARAM,
+		        ServletEngine.SSL_CERT_ALIAS_PARAM);
+		
 	}
 	
 	static final String CONTEXT_DESC = "Define a URL context path that maps to the resources defined by" + 

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/TupleView.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/TupleView.java
@@ -4,13 +4,13 @@
 */
 package com.ibm.streamsx.inet.rest.ops;
 
+import com.ibm.streams.operator.model.Icons;
 import com.ibm.streams.operator.model.InputPortSet;
 import com.ibm.streams.operator.model.InputPortSet.WindowMode;
 import com.ibm.streams.operator.model.InputPortSet.WindowPunctuationInputMode;
 import com.ibm.streams.operator.model.InputPorts;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.Icons;
 
 @PrimitiveOperator(name=TupleView.opName, description=TupleView.DESC)
 // Require at least one input port
@@ -28,7 +28,7 @@ public class TupleView extends ServletOperator {
 	@Parameter(optional=true, cardinality=-1, description="Names of attributes to partition the window by")
 	public void setPartitionKey(String[] attributeNames) {}
 	
-	static final String DESC = "REST HTTP API to view tuples from windowed input ports.\\n" + 
+	static final String DESC = "REST HTTP or HTTPS API to view tuples from windowed input ports.\\n" + 
 			"Embeds a Jetty web server to provide HTTP REST access to the collection of tuples in " + 
 			"the input port window at the time of the last eviction for tumbling windows, " + 
 			"or last trigger for sliding windows." +
@@ -69,5 +69,5 @@ public class TupleView extends ServletOperator {
 			"\\n" + 
 			"**Limitations**:\\n" + 
 			"* Error handling is limited, incorrect URLs can crash the application, e.g. providing the wrong number of partition values.\\n" + 
-			"* No security access is provided to the data or applications. This is mainly aimed at demos.\\n";
+			"* By default no security access is provided to the data, HTTPS must be explicitly configured.\\n";
 }

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/WebContext.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/WebContext.java
@@ -7,9 +7,9 @@
 */
 package com.ibm.streamsx.inet.rest.ops;
 
+import com.ibm.streams.operator.model.Icons;
 import com.ibm.streams.operator.model.Parameter;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.Icons;
 
 /**
  * Operator without any ports that simply defines a webcontext.
@@ -27,9 +27,8 @@ public class WebContext extends ServletOperator {
 	@Parameter(description=CRB_DESC)
 	public void setContextResourceBase(String base) {}
 	
-	static final String DESC = "Embeds a Jetty web server to provide HTTP REST access to files defined by the `context` and `contextResourceBase` parameters.\\n" + 
+	static final String DESC = "Embeds a Jetty web server to provide HTTP or HTTPS REST access to files defined by the `context` and `contextResourceBase` parameters.\\n" + 
 			"**Limitations**:\\n" + 
-			" * No security access is provided to the served files or applications. This is mainly aimed " + 
-			"at demos.";
+			" * By default no security access is provided to the data, HTTPS must be explicitly configured.";
 
 }

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/XMLView.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/XMLView.java
@@ -15,10 +15,10 @@ import com.ibm.streams.operator.StreamingInput;
 import com.ibm.streams.operator.Tuple;
 import com.ibm.streams.operator.Type.MetaType;
 import com.ibm.streams.operator.compile.OperatorContextChecker;
+import com.ibm.streams.operator.model.Icons;
 import com.ibm.streams.operator.model.InputPortSet;
 import com.ibm.streams.operator.model.InputPortSet.WindowMode;
 import com.ibm.streams.operator.model.PrimitiveOperator;
-import com.ibm.streams.operator.model.Icons;
 
 @PrimitiveOperator(name="HTTPXMLView", description=XMLView.DESC)
 @InputPortSet(cardinality=1,windowingMode=WindowMode.NonWindowed,
@@ -67,9 +67,9 @@ public class XMLView extends ServletOperator {
 		portData.put(port.getPortNumber(), new Object[] {tuple.getXML(attributeIndex), System.currentTimeMillis()});
 	}
 	
-	static final String DESC = "REST HTTP API to view tuples from windowed input ports.\\n" + 
-			"Embeds a Jetty web server to provide HTTP REST access to the first XML attribute of the last tuple received by " + 
-			"the input port window." +
+	static final String DESC = "REST API to view tuples from input ports.\\n" + 
+			"Embeds a Jetty web server to provide HTTP or HTTPS REST access to the first XML attribute of the last tuple received by " + 
+			"the input port." +
 			"\\n" +
 			"The URLs defined by this operator are:\\n" +
 			"* *prefix*`/ports/input/`*port index*`/attribute` - Returns the value of the XML attribute (content type `application/xml`).\\n" +
@@ -81,6 +81,6 @@ public class XMLView extends ServletOperator {
 			"The input port schema must contain an XML attribute whose value will be made available through the `/tuple` URL.\\n" + 
 			"\\n" + 
 			"**Limitations**:\\n" + 
-			"* No security access is provided to the data or applications. This is mainly aimed at demos.\\n";
+			"* By default no security access is provided to the data, HTTPS must be explicitly configured.\\n";
 
 }


### PR DESCRIPTION
fixes #131 

Adds four parameters to the REST operators that config use of a certificate from a key store to support SSL.