### PR TITLE
Add option for adding arbitrary headers to HTTP operators

### DIFF
--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/AbstractHTTPGetContent.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/AbstractHTTPGetContent.java
@@ -6,6 +6,8 @@ package com.ibm.streamsx.inet.http;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import org.apache.http.HttpEntity;
@@ -35,6 +37,7 @@ public abstract class AbstractHTTPGetContent<A> extends
             .getLogger("com.ibm.streamsx.inet.http");
 
     private String url;
+    private List<String> extraHeaders;
 
     private HttpClient client;
     protected URIBuilder builder;
@@ -52,6 +55,11 @@ public abstract class AbstractHTTPGetContent<A> extends
     @Parameter(description = "URL to HTTP GET content from.")
     public void setUrl(String url) {
         this.url = url;
+    }
+    
+    @Parameter(optional = true, description = "Extra headers to send with request, format is \\\"Header-Name: value\\\"")
+    public void setExtraHeaders(List<String> extraHeaders) {
+    	this.extraHeaders = extraHeaders;
     }
 
     public Metric getnFailedRequests() {
@@ -85,6 +93,11 @@ public abstract class AbstractHTTPGetContent<A> extends
                     .getIndex();
         else
             contentAttributeIndex = defaultContentAttributeIndex();
+        
+        Map<String, String> extraHeaderMap = HTTPUtils.getHeaderMap(extraHeaders);
+        for(Map.Entry<String, String> header : extraHeaderMap.entrySet()) {
+            get.setHeader(header.getKey(), header.getValue());
+        }
     }
 
     protected abstract String acceptedContentTypes();

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPPostOper.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPPostOper.java
@@ -73,6 +73,8 @@ public class HTTPPostOper extends AbstractOperator
 	
 	private String headerContentType = MIME_FORM;
 
+	private List<String> extraHeaders = new ArrayList<String>();
+
 	@Parameter(optional= false, description="URL to connect to")
 	public void setUrl(String url) {
 		this.url = url;
@@ -108,6 +110,10 @@ public class HTTPPostOper extends AbstractOperator
 			" Note that if a value other than the above mentioned ones is specified, the input stream can only have a single attribute.")
 	public void setHeaderContentType(String val) {
 		this.headerContentType = val;
+	}
+	@Parameter(optional=true, description="Extra headers to send with request, format is \\\"Header-Name: value\\\".")
+	public void setExtraHeaders(List<String> val) {
+		this.extraHeaders = val;
 	}
 	
 	//consistent region checks
@@ -173,6 +179,11 @@ public class HTTPPostOper extends AbstractOperator
 		}
 		else {
 			req.setParams(tuple.getObject(schema.getAttribute(0).getName()).toString());
+		}
+
+		Map<String, String> headerMap = HTTPUtils.getHeaderMap(extraHeaders);
+		for(Map.Entry<String, String> header : headerMap.entrySet()) {
+			req.setHeader(header.getKey(), header.getValue());
 		}
 
 		HTTPResponse resp = null;

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReaderObj.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReaderObj.java
@@ -48,7 +48,7 @@ class HTTPStreamReaderObj implements Runnable
 	
 	public HTTPStreamReaderObj(String url, IAuthenticate auth, 
 			HTTPStreamReader reader,  Map<String, String> postD, 
-			boolean disableCompression) 
+			boolean disableCompression, Map<String, String> extraHeaders) 
 			throws Exception 	{
 		this.auth = auth;
 		this.reader = reader;
@@ -62,6 +62,9 @@ class HTTPStreamReaderObj implements Runnable
 		}
 		else {
 			req.setHeader("Accept-Encoding", "identity");
+		}
+		for(Map.Entry<String, String> header : extraHeaders.entrySet()) {
+			req.setHeader(header.getKey(), header.getValue());
 		}
 		req.setParams(postData);
 	}

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPUtils.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPUtils.java
@@ -12,6 +12,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HTTPUtils {
 
@@ -38,5 +41,16 @@ public class HTTPUtils {
 			//ignore
 		}
 		return buf.toString();
+	}
+
+	public static Map<String, String> getHeaderMap(List<String> headers) {
+		Map<String, String> headerMap = new HashMap<String, String>(headers.size());
+		for(String header : headers) {
+			String[] headerParts = header.split(":\\s*", 2);
+			String headerName = headerParts[0];
+			String headerValue = headerParts[1];
+			headerMap.put(headerName, headerValue);
+		}
+		return headerMap;
 	}
 }


### PR DESCRIPTION
Add "extraHeaders" parameter which takes a list of Strings in a multivalued format as follows
```
extraHeaders: "X-Header1: value1", "X-Header2: value2"
                         ^                    ^
zero or more spaces    here                 and here
```