### PR TITLE
Add input port to HTTPGetStream operator

### DIFF
--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReaderObj.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReaderObj.java
@@ -84,13 +84,7 @@ class HTTPStreamReaderObj implements Runnable
 	public void sendRequest() throws Exception 	{
 		while(!shutdown) {
 			try {
-				HTTPResponse resp = newConnection();
-				in = new BufferedReader(new InputStreamReader(resp.getInputStream()));
-				reader.connectionSuccess();
-				String inputLine = null;
-				while (!shutdown && ((inputLine = in.readLine()) != null)) {
-					reader.processNewLine(inputLine);
-				}
+				sendSingleRequest();
 				if(shutdown || !reader.connectionClosed())
 					break;
 			}catch(Exception e) {
@@ -104,6 +98,16 @@ class HTTPStreamReaderObj implements Runnable
 				}catch(Exception e) {}
 				in = null;
 			}
+		}
+	}
+
+	public void sendSingleRequest() throws Exception {
+		HTTPResponse resp = newConnection();
+		in = new BufferedReader(new InputStreamReader(resp.getInputStream()));
+		reader.connectionSuccess();
+		String inputLine = null;
+		while (!shutdown && ((inputLine = in.readLine()) != null)) {
+			reader.processNewLine(inputLine);
 		}
 	}
 


### PR DESCRIPTION
#152

Each tuple received through the added input port of the HTTPGetStream operator will initiate an HTTP request. This way, the operator can make periodic requests in response to events that happen in other parts of the streams application.

In this change, the input tuple's contents are ignored, but in the future the tuple could send information in order to make the request (e.g. the URL could be passed through the input port).