### PR TITLE
Add toggle to allow bad SSL certificates to HTTP operators

### DIFF
--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/AbstractHTTPGetContent.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/AbstractHTTPGetContent.java
@@ -47,6 +47,8 @@ public abstract class AbstractHTTPGetContent<A> extends
     protected int contentAttributeIndex;
 
     private Metric nFailedRequests;
+    
+    boolean acceptAllCertificates = false;
 
     public String getUrl() {
         return url;
@@ -60,6 +62,12 @@ public abstract class AbstractHTTPGetContent<A> extends
     @Parameter(optional = true, description = "Extra headers to send with request, format is \\\"Header-Name: value\\\"")
     public void setExtraHeaders(List<String> extraHeaders) {
     	this.extraHeaders = extraHeaders;
+    }
+
+    @Parameter(optional = true, description = "Accept all SSL certificates, even those that are self-signed. " +
+			"Setting this option will allow potentially insecure connections. Default is false.")
+    public void setAcceptAllCertificates(boolean acceptAllCertificates) {
+        this.acceptAllCertificates = acceptAllCertificates;
     }
 
     public Metric getnFailedRequests() {
@@ -81,7 +89,12 @@ public abstract class AbstractHTTPGetContent<A> extends
     public synchronized void initialize(OperatorContext context)
             throws Exception {
         super.initialize(context);
-        client = new DefaultHttpClient();
+
+        if(acceptAllCertificates)
+        	client = HTTPUtils.getHttpClientWithNoSSLValidation();
+        else
+        	client = new DefaultHttpClient();
+        
         builder = new URIBuilder(getUrl());
         get = new HttpGet(builder.build());
         get.addHeader("Accept", acceptedContentTypes());

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPPostOper.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPPostOper.java
@@ -72,6 +72,7 @@ public class HTTPPostOper extends AbstractOperator
 	private List<String> authenticationProperties = new ArrayList<String>();
 	
 	private String headerContentType = MIME_FORM;
+	private boolean acceptAllCertificates = false;
 
 	private List<String> extraHeaders = new ArrayList<String>();
 
@@ -111,9 +112,16 @@ public class HTTPPostOper extends AbstractOperator
 	public void setHeaderContentType(String val) {
 		this.headerContentType = val;
 	}
-	@Parameter(optional=true, description="Extra headers to send with request, format is \\\"Header-Name: value\\\".")
+	@Parameter(optional=true,
+			description="Extra headers to send with request, format is \\\"Header-Name: value\\\".")
 	public void setExtraHeaders(List<String> val) {
 		this.extraHeaders = val;
+	}
+	@Parameter(optional=true, 
+			description="Accept all SSL certificates, even those that are self-signed. " +
+			"Setting this option will allow potentially insecure connections. Default is false.")
+	public void setAcceptAllCertificates(boolean val) {
+		this.acceptAllCertificates = val;
 	}
 	
 	//consistent region checks
@@ -165,6 +173,7 @@ public class HTTPPostOper extends AbstractOperator
 		HTTPRequest req = new HTTPRequest(url);
 		req.setHeader("Content-Type", headerContentType);
 		req.setType(RequestType.POST);
+		req.setInsecure(acceptAllCertificates);
 
 		if(headerContentType.equals(MIME_FORM)) {
 			Map<String, String> params = new HashMap<String, String>();

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPRequest.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPRequest.java
@@ -38,6 +38,7 @@ class HTTPRequest {
 
 	public static enum RequestType {GET, POST};
 	private RequestType type = RequestType.GET;
+	private boolean insecure = false;
 
 	private HttpUriRequest req = null;
 	private HttpEntity entity = null;
@@ -64,6 +65,14 @@ class HTTPRequest {
 
 	HttpUriRequest getReq() {
 		return req;
+	}
+
+	public boolean isInsecure() {
+		return insecure;
+	}
+
+	public void setInsecure(boolean insecure) {
+		this.insecure = insecure;
 	}
 
 	/**
@@ -100,7 +109,14 @@ class HTTPRequest {
 	 * @throws Exception
 	 */
 	public HTTPResponse sendRequest(IAuthenticate auth) throws Exception {
-		HttpClient client = new DefaultHttpClient();
+		HttpClient client;
+		if(insecure) {
+			client = HTTPUtils.getHttpClientWithNoSSLValidation();
+		}
+		else {
+			client = new DefaultHttpClient();
+		}
+		
 		if(type == RequestType.GET) {
 			HttpGet get = new HttpGet(url);
 			req=get;
@@ -123,8 +139,6 @@ class HTTPRequest {
 		
 		return new HTTPResponse(client.execute(req));
 	}
-
-
 
 	@Override
 	public String toString() {

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReader.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReader.java
@@ -63,6 +63,7 @@ public class HTTPStreamReader extends AbstractOperator {
 	private static Logger trace = Logger.getLogger(CLASS_NAME);
 	private boolean retryOnClose = false;
 	private boolean disableCompression = false;
+	private boolean acceptAllCertificates = false;
 
 	@Parameter(optional= false, description="URL endpoint to connect to.")
 	public void setUrl(String url) {
@@ -122,6 +123,12 @@ public class HTTPStreamReader extends AbstractOperator {
 	@Parameter(optional=true, description="Extra headers to send with request, format is \\\"Header-Name: value\\\".")
 	public void setExtraHeaders(List<String> val) {
 		this.extraHeaders = val;
+	}
+	@Parameter(optional=true, 
+			description="Accept all SSL certificates, even those that are self-signed. " +
+			"Setting this option will allow potentially insecure connections. Default is false.")
+	public void setAcceptAllCertificates(boolean val) {
+		this.acceptAllCertificates = val;
 	}
 
 	@ContextCheck(compile=true)
@@ -189,8 +196,7 @@ public class HTTPStreamReader extends AbstractOperator {
         URI baseConfigURI = op.getPE().getApplicationDirectory().toURI();
 		IAuthenticate auth = AuthHelper.getAuthenticator(authenticationType, PathConversionHelper.convertToAbsPath(baseConfigURI, authenticationFile), authenticationProperties);
 		Map<String, String> extraHeaderMap = HTTPUtils.getHeaderMap(extraHeaders);
-		
-		reader = new HTTPStreamReaderObj(this.url, auth, this, postDataParams, disableCompression, extraHeaderMap);
+		reader = new HTTPStreamReaderObj(this.url, auth, this, postDataParams, disableCompression, extraHeaderMap, acceptAllCertificates);
 		th = op.getThreadFactory().newThread(reader);
 		th.setDaemon(false);
 	}

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReaderObj.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPStreamReaderObj.java
@@ -48,7 +48,8 @@ class HTTPStreamReaderObj implements Runnable
 	
 	public HTTPStreamReaderObj(String url, IAuthenticate auth, 
 			HTTPStreamReader reader,  Map<String, String> postD, 
-			boolean disableCompression, Map<String, String> extraHeaders) 
+			boolean disableCompression, Map<String, String> extraHeaders,
+			boolean insecure) 
 			throws Exception 	{
 		this.auth = auth;
 		this.reader = reader;
@@ -67,6 +68,7 @@ class HTTPStreamReaderObj implements Runnable
 			req.setHeader(header.getKey(), header.getValue());
 		}
 		req.setParams(postData);
+		req.setInsecure(insecure);
 	}
 	
 

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPUtils.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPUtils.java
@@ -15,6 +15,21 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.BasicClientConnectionManager;
 
 public class HTTPUtils {
 
@@ -52,5 +67,29 @@ public class HTTPUtils {
 			headerMap.put(headerName, headerValue);
 		}
 		return headerMap;
+	}
+	
+	public static HttpClient getHttpClientWithNoSSLValidation() throws Exception {
+		SSLContext sslContext = SSLContext.getInstance("SSL");
+		sslContext.init(null, new TrustManager[] {
+			new X509TrustManager() {
+				public X509Certificate[] getAcceptedIssuers() {
+					return null;
+				}
+				public void checkClientTrusted(X509Certificate[] certs, String authType) {
+				}
+				public void checkServerTrusted(X509Certificate[] certs, String authType) {
+				}
+			}
+		}, new SecureRandom());
+
+		SSLSocketFactory sf = new SSLSocketFactory(sslContext, new AllowAllHostnameVerifier());
+		Scheme httpsScheme = new Scheme("https", 443, sf);
+		SchemeRegistry schemeRegistry = new SchemeRegistry();
+		schemeRegistry.register(httpsScheme);
+
+		ClientConnectionManager cm = new BasicClientConnectionManager(schemeRegistry);
+
+		return new DefaultHttpClient(cm);
 	}
 }


### PR DESCRIPTION
Solves issue IBMStreams/streamsx.inet#150

This pull request adds the "acceptAllCertificates" boolean parameter to HTTPPost, HTTPGetStream, HTTPGetJSONContent, and HTTPGetXMLContent.

HTTPPost and HTTPGetStream do this through HTTPRequest,
HTTPGetJSONContent and HTTPGetXMLContent do this through AbstractHTTPGetContent.

Both HTTPRequest and AbstractHTTPGetContent retrieve the special (no validation) HttpClient from HTTPUtils.