### PR TITLE
Add defensive code behind extraHeaders

### DIFF
--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPUtils.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPUtils.java
@@ -12,9 +12,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
@@ -31,7 +33,12 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.BasicClientConnectionManager;
 
+import com.ibm.streams.operator.logging.TraceLevel;
+
 public class HTTPUtils {
+
+	static final String CLASS_NAME="com.ibm.streamsx.inet.http.HTTPUtils";
+	private static Logger trace = Logger.getLogger(CLASS_NAME);
 
 	public static HttpURLConnection getNewConnection(String url) 
 			throws IOException {
@@ -59,9 +66,14 @@ public class HTTPUtils {
 	}
 
 	public static Map<String, String> getHeaderMap(List<String> headers) {
+		if(headers == null) return Collections.emptyMap();
 		Map<String, String> headerMap = new HashMap<String, String>(headers.size());
 		for(String header : headers) {
 			String[] headerParts = header.split(":\\s*", 2);
+			if(headerParts.length < 2) {
+				trace.log(TraceLevel.ERROR, "No ':' found in extraHeaders element '" + header + "', skipping");
+				continue;
+			}
 			String headerName = headerParts[0];
 			String headerValue = headerParts[1];
 			headerMap.put(headerName, headerValue);


### PR DESCRIPTION
Fixes a null pointer error in extraHeaders parameter processing. Also logs an error if an invalid header string is encountered. (valid is "Header-Name: Header-Value")

@ddebrunner 