### PR TITLE
Correct include path in ftp operators-xml files

### DIFF
--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPCommand/FTPCommand.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPCommand/FTPCommand.xml
@@ -80,7 +80,7 @@ The command string and the command arguments are received from port 0.
           <cmn:managedLibrary>
             <cmn:lib>inettoolkit</cmn:lib>
             <cmn:libPath>../../impl/lib</cmn:libPath>
-            <cmn:includePath>../../impl/cpp/include/libftp</cmn:includePath>
+            <cmn:includePath>../../impl/cpp/include</cmn:includePath>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPPutFile/FTPPutFile.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPPutFile/FTPPutFile.xml
@@ -106,7 +106,7 @@ You can optionally rename the file after you complete the transfer.</description
           <cmn:managedLibrary>
             <cmn:lib>inettoolkit</cmn:lib>
             <cmn:libPath>../../impl/lib</cmn:libPath>
-            <cmn:includePath>../../impl/cpp/include/libftp</cmn:includePath>
+            <cmn:includePath>../../impl/cpp/include</cmn:includePath>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPReader/FTPReader.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet.ftp/FTPReader/FTPReader.xml
@@ -129,7 +129,7 @@ character. An complete empty line indicates an empty file. This function must no
           <cmn:managedLibrary>
             <cmn:lib>inettoolkit</cmn:lib>
             <cmn:libPath>../../impl/lib</cmn:libPath>
-            <cmn:includePath>../../impl/cpp/include/libftp</cmn:includePath>
+            <cmn:includePath>../../impl/cpp/include</cmn:includePath>
           </cmn:managedLibrary>
         </library>
       </libraryDependencies>


### PR DESCRIPTION
In the ftp operators operator model the changed include file directory must be corrected.