### PR TITLE
Add support for ppc64 in impl/Makefile for cpp

### DIFF
--- a/com.ibm.streamsx.inet/impl/Makefile
+++ b/com.ibm.streamsx.inet/impl/Makefile
@@ -4,6 +4,15 @@ $(info ************************************************************************)
 $(info ***  make libftp                                                     ***)
 $(info ************************************************************************)
 
+# Handle PPC platforms that require toolchain Compiler
+ifeq ($(CXX),g++)
+  PLATFORM := $(shell uname -i)
+  ifeq ($(PLATFORM),ppc64)
+    CXX=/opt/at7.0/bin/g++
+  endif
+endif
+
+
 # InfoSphere Streams Compiler/Linker Options
 SPL_PKGCFG=$(realpath $(STREAMS_INSTALL)/bin/dst-pe-pkg-config.sh)
 ifeq "" "$(SPL_PKGCFG)"


### PR DESCRIPTION
Enhance impl/Makefile to check platform architecture, and if ppc64 override the CXX compiler to use the Advanced Toolchain Compiler required by Streams on Power.  (Thanks to Walt Madden for the solution)