### PR TITLE
Variable thread pool

### DIFF
--- a/com.ibm.streamsx.inet/impl/Makefile
+++ b/com.ibm.streamsx.inet/impl/Makefile
@@ -4,6 +4,15 @@ $(info ************************************************************************)
 $(info ***  make libftp                                                     ***)
 $(info ************************************************************************)
 
+# Handle PPC platforms that require toolchain Compiler
+ifeq ($(CXX),g++)
+  PLATFORM := $(shell uname -i)
+  ifeq ($(PLATFORM),ppc64)
+    CXX=/opt/at7.0/bin/g++
+  endif
+endif
+
+
 # InfoSphere Streams Compiler/Linker Options
 SPL_PKGCFG=$(realpath $(STREAMS_INSTALL)/bin/dst-pe-pkg-config.sh)
 ifeq "" "$(SPL_PKGCFG)"


### PR DESCRIPTION
Create the ThreadPoolExecuter corePoolSize based on the algorithm tha jetty 8.1.3 uses to determine how many initial threads to start (SelectorManager and AbstractConnector.Acceptor) which is based on Runtime.getRuntime().availableProcessors().  The issue arose on large ppc nodes on which jetty attempted to startup > 32 initial threads and the corePoolSize was set to 32.  The application would run, but was unresponsive to HTTP requests.