### PR TITLE
Add missing target attribute for Java 7 to ensure toolkit runs on 4.0.0

### DIFF
--- a/com.ibm.streamsx.inet/build.xml
+++ b/com.ibm.streamsx.inet/build.xml
@@ -133,7 +133,9 @@ artifacts were left around and caused issues with the ant build.
 
 
 	<target name="compile" depends="init, maven-deps">
-		<javac srcdir="${src.dir}" destdir="${build.dir}" debug="true" includeantruntime="no" source="1.7" excludes="com/ibm/streamsx/inet/rest/test/**">
+		<javac srcdir="${src.dir}" destdir="${build.dir}" debug="true" includeantruntime="no"
+		     source="1.7" target="1.7"
+		     excludes="com/ibm/streamsx/inet/rest/test/**">
 			<classpath>
 				<path refid="cp.compile" />
 			</classpath>


### PR DESCRIPTION
The target attribute to set the Java class level was incorrectly removed in an earlier commit:

https://github.com/IBMStreams/streamsx.inet/commit/e96828424ba732e4eea5d2631c48abf0bf7c33ca

Rather than being removed it should have been updated to the required version.