### PR TITLE
Add support for handling jsonString specially

### DIFF
--- a/com.ibm.streamsx.inet/build.xml
+++ b/com.ibm.streamsx.inet/build.xml
@@ -135,7 +135,7 @@ artifacts were left around and caused issues with the ant build.
 	<target name="compile" depends="init, maven-deps">
 		<javac srcdir="${src.dir}" destdir="${build.dir}" debug="true" includeantruntime="no"
 		     source="1.7" target="1.7"
-		     excludes="com/ibm/streamsx/inet/rest/test/**">
+		     excludes="com/ibm/streamsx/inet/*/test/**">
 			<classpath>
 				<path refid="cp.compile" />
 			</classpath>
@@ -158,7 +158,7 @@ artifacts were left around and caused issues with the ant build.
 		<mkdir dir="${test.run.dir}" />
 		<mkdir dir="${test.build.dir}" />
 
-		<javac srcdir="${src.dir}" destdir="${test.build.dir}" debug="true" includeantruntime="yes" includes="com/ibm/streamsx/inet/rest/test/**">
+		<javac srcdir="${src.dir}" destdir="${test.build.dir}" debug="true" includeantruntime="yes" includes="com/ibm/streamsx/inet/*/test/**">
 			<classpath>
 				<pathelement location="${impl.lib.dir}/${jarfile}" />
 				<path refid="cp.streams" />

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPPostOper.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPPostOper.java
@@ -148,7 +148,8 @@ public class HTTPPostOper extends AbstractOperator
 		this.retryDelay = val;
 	}
 	@Parameter(optional=true, description="Set the content type of the HTTP request. " +
-			" If the value is set to \\\""+MIME_JSON+"\\\" then the entire tuple is sent in JSON format. " +
+			" If the value is set to \\\""+MIME_JSON+"\\\" then the entire tuple is sent in JSON format using SPL's standard tuple to JSON encoding, "
+			        + "if the input schema is `tuple<rstring jsonString>` then `jsonString` is assumed to already be JSON and its value is sent as the content. " +
 			" Default is \\\""+MIME_FORM+"\\\"." +
 			" Note that if a value other than the above mentioned ones is specified, the input stream can only have a single attribute.")
 	public void setHeaderContentType(String val) {

--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/test/HttpPostTest.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/test/HttpPostTest.java
@@ -1,0 +1,79 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2014 
+ */
+package com.ibm.streamsx.inet.http.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ibm.json.java.JSON;
+import com.ibm.json.java.JSONObject;
+import com.ibm.streams.flow.declare.InputPortDeclaration;
+import com.ibm.streams.flow.declare.OperatorGraph;
+import com.ibm.streams.flow.declare.OperatorGraphFactory;
+import com.ibm.streams.flow.declare.OperatorInvocation;
+import com.ibm.streams.flow.declare.OutputPortDeclaration;
+import com.ibm.streams.flow.handlers.MostRecent;
+import com.ibm.streams.flow.javaprimitives.JavaOperatorTester;
+import com.ibm.streams.flow.javaprimitives.JavaTestableGraph;
+import com.ibm.streams.operator.OutputTuple;
+import com.ibm.streams.operator.StreamingOutput;
+import com.ibm.streams.operator.Tuple;
+import com.ibm.streams.operator.types.RString;
+import com.ibm.streamsx.inet.http.HTTPPostOper;
+
+public class HttpPostTest {
+
+    /**
+     * Test HTTPPost sends JSON as-is 
+     * when content type is application/json
+     * and the input schema is tuple<rstring jsonString>
+     * the standard JSON type.
+     */
+    @Test
+    public void testJSONInputAsis() throws Exception {
+        OperatorGraph graph = OperatorGraphFactory.newGraph();
+
+        OperatorInvocation<HTTPPostOper> op = graph.addOperator("TestJSONStringAttribute", HTTPPostOper.class);
+        op.setStringParameter("headerContentType", "application/json");
+        op.setStringParameter("url", "http://httpbin.org/post");
+
+        InputPortDeclaration tuplesToPost = op
+                .addInput("tuple<rstring jsonString>");
+        
+        OutputPortDeclaration postReturn = op.addOutput("tuple<rstring data, rstring errorMessage, int32 responseCode, int32 dataSize>");
+        
+        // Create the testable version of the graph
+        JavaTestableGraph testableGraph = new JavaOperatorTester()
+                .executable(graph);
+
+        // Create the injector to inject test tuples.
+        StreamingOutput<OutputTuple> injector = testableGraph.getInputTester(tuplesToPost);
+        
+        MostRecent<Tuple> mr = new MostRecent<>();
+        
+        testableGraph.registerStreamHandler(postReturn, mr);
+        
+        // Execute the initialization of operators within graph.
+        testableGraph.initialize().get().allPortsReady().get();
+        
+        // Create a JSON object for the jsonString attribute.
+        JSONObject json = new JSONObject();
+        json.put("b", 37l);
+        json.put("c", "HelloWorld!");
+        
+        // and submit to the operator
+        injector.submitAsTuple(new RString(json.serialize()));
+        
+        String returnedData = mr.getMostRecentTuple().getString("data");
+        JSONObject returnedJson = (JSONObject) JSON.parse(returnedData);
+        assertEquals("application/json", ((JSONObject) returnedJson.get("headers")).get("Content-Type"));
+        
+        String jsonData = (String) returnedJson.get("data");
+        assertEquals(json, JSON.parse(jsonData));
+
+        testableGraph.shutdown().get();
+    }
+}

--- a/com.ibm.streamsx.inet/info.xml
+++ b/com.ibm.streamsx.inet/info.xml
@@ -48,7 +48,7 @@ Alternatively, you can fully qualify the operators that are provided by toolkit 
 4. Start the InfoSphere Streams instance. 
 5. Run the application. You can submit the application as a job by using the **streamtool submitjob** command or by using Streams Studio. 
     </description>
-    <version>2.7.2</version>
+    <version>2.7.3</version>
     <requiredProductVersion>4.0.0.0</requiredProductVersion>
   </identity>
   <dependencies/>


### PR DESCRIPTION
For HTTPPost operator is the content type is application/json and the input scheme is `tuple<rstring jsonString>` then use the tuple's single attribute value as the content, since it is already JSON.

While this would be a change in behaviour, the current behaviour is not useful and I've had to help out several folks who tried to do this.

Bascially currently the JOSNis encoded in json as a string value, leading to a value that is not close to the orignal JSON.

This is for #187

Also uses an enum for selecting the action to perform on each tuple, rather than potentially multiple string comparisions.