### PR TITLE
add parseDatestring() function to com.ibm.streamsx.inet 

### DIFF
--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetRetrieverCpp.cgt
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/InetSource/InetRetrieverCpp.cgt
@@ -46,7 +46,11 @@ MY_OPERATOR::InetRetriever::InetRetriever(const std::string& url, const int time
     curl_easy_setopt(_curlHandle, CURLOPT_FILETIME, 1);
 
     // accept all supported built-in compression methods
+#ifdef CURLOPT_ACCEPT_ENCODING
     curl_easy_setopt(_curlHandle, CURLOPT_ACCEPT_ENCODING, "");
+#elseif CURLOPT_ENCODING
+    curl_easy_setopt(_curlHandle, CURLOPT_ENCODING, "");
+#endif
 
     // some servers insist on knowing who is asking
     curl_easy_setopt(_curlHandle, CURLOPT_USERAGENT, "IBMStreams/4.0");

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/native.function/function.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/native.function/function.xml
@@ -6,7 +6,59 @@
     <function:functions>
       <function:function>
         <function:description>
-        This function converts a string that specifies a calendar date and time into an integer containing the corresponding 'unix epoch' value. It recognizes all of the date and time formats allowed in HTTP messages. For details, see [https://curl.haxx.se/libcurl/c/curl_getdate.html].
+
+        This function converts a string that specifies a date and time into a
+        64-bit integer corresponding to the 'unix epoch' value of that date and
+        time, which is the number of seconds since midnight on January 1st, 1970
+        in Greenwich, England. It recognizes all of the date and time formats
+        allowed in HTTP messages. For example:
+
+        Sun, 06 Nov 1994 08:49:37 GMT
+
+        Sunday, 06-Nov-94 08:49:37 GMT
+
+        Sun Nov  6 08:49:37 1994
+
+        06 Nov 1994 08:49:37 GMT
+
+        06-Nov-94 08:49:37 GMT
+
+        Nov  6 08:49:37 1994
+
+        06 Nov 1994 08:49:37
+
+        06-Nov-94 08:49:37
+
+        1994 Nov 6 08:49:37
+
+        GMT 08:49:37 06-Nov-94 Sunday
+
+        94 6 Nov 08:49:37
+
+        1994 Nov 6
+
+        06-Nov-94
+
+        Sun Nov 6 94
+
+        1994.Nov.6
+
+        Sun/Nov/6/94/GMT
+
+        Sun, 06 Nov 1994 08:49:37 CET
+
+        06 Nov 1994 08:49:37 EST
+
+        Sun, 12 Sep 2004 15:05:58 -0700
+
+        Sat, 11 Sep 2004 21:32:11 +0200
+
+        20040912 15:05:58 -0700
+
+        20040911 +0200
+
+        For details, see [https://curl.haxx.se/libcurl/c/curl_getdate.html].
+
         </function:description>
         <function:prototype>public int64 parseDatestring(rstring datestring)</function:prototype>
       </function:function>

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/native.function/function.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/native.function/function.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="ASCII"?>
+<function:functionModel xmlns:common="http://www.ibm.com/xmlns/prod/streams/spl/common" xmlns:function="http://www.ibm.com/xmlns/prod/streams/spl/function">
+  <function:functionSet>
+    <function:headerFileName>parseDatestring.h</function:headerFileName>
+    <function:cppNamespaceName>com::ibm::streamsx::inet</function:cppNamespaceName>
+    <function:functions>
+      <function:function>
+        <function:description>
+        This function converts a string that specifies a calendar date and time into an integer containing the corresponding 'unix epoch' value. It recognizes all of the date and time formats allowed in HTTP messages. For details, see [https://curl.haxx.se/libcurl/c/curl_getdate.html].
+        </function:description>
+        <function:prototype>public int64 parseDatestring(rstring datestring)</function:prototype>
+      </function:function>
+    </function:functions>
+    <function:dependencies>
+      <function:library>
+        <common:description/>
+        <common:managedLibrary/>
+      </function:library>
+      <function:library>
+        <common:description>'curl' library</common:description>
+        <common:managedLibrary>
+          <common:lib>curl</common:lib>
+          <common:includePath>../../impl/include</common:includePath>
+        </common:managedLibrary>
+      </function:library>
+    </function:dependencies>
+  </function:functionSet>
+</function:functionModel>

--- a/com.ibm.streamsx.inet/com.ibm.streamsx.inet/native.function/function.xml
+++ b/com.ibm.streamsx.inet/com.ibm.streamsx.inet/native.function/function.xml
@@ -13,10 +13,6 @@
     </function:functions>
     <function:dependencies>
       <function:library>
-        <common:description/>
-        <common:managedLibrary/>
-      </function:library>
-      <function:library>
         <common:description>'curl' library</common:description>
         <common:managedLibrary>
           <common:lib>curl</common:lib>

--- a/com.ibm.streamsx.inet/impl/include/parseDatestring.h
+++ b/com.ibm.streamsx.inet/impl/include/parseDatestring.h
@@ -1,0 +1,20 @@
+/*
+** Copyright (C) 2017  International Business Machines Corporation
+** All Rights Reserved
+*/
+
+#ifndef PARSEDATESTRING_H_
+#define PARSEDATESTRING_H_
+
+#include <curl/curl.h>
+
+#include "SPL/Runtime/Function/SPLFunctions.h"
+
+#define ESC_CHAR '\\' 
+namespace com { namespace ibm { namespace streamsx { namespace inet {
+
+        static SPL::int64 parseDatestring(SPL::rstring datestring) { return curl_getdate(datestring.c_str(), NULL); }
+
+} } } }
+
+#endif /* PARSEDATESTRING_H_ */


### PR DESCRIPTION
This function converts a string that specifies a calendar date and time into an integer containing the corresponding 'unix epoch' value. It recognizes all of the date and time formats allowed in HTTP messages. For details, see [https://curl.haxx.se/libcurl/c/curl_getdate.html].
