### PR TITLE
Mark response port as a control port

### DIFF
--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/HTTPTupleRequest.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/rest/ops/HTTPTupleRequest.java
@@ -90,7 +90,7 @@ import com.ibm.streams.operator.types.RString;
 @PrimitiveOperator(name = "HTTPTupleRequest", namespace = "com.ibm.streamsx.inet.rest", description = HTTPTupleRequest.DESC)
 @Libraries(value = { "opt/eclipse-4.2.2/plugins/*" })
 @InputPorts({
-		@InputPortSet(description = "Response to be returned to the web requestor.", cardinality = 1, optional = false, windowingMode = WindowMode.NonWindowed, windowPunctuationInputMode = WindowPunctuationInputMode.Oblivious)})
+		@InputPortSet(description = "Response to be returned to the web requestor.", cardinality = 1, optional = false, controlPort=true, windowingMode = WindowMode.NonWindowed, windowPunctuationInputMode = WindowPunctuationInputMode.Oblivious)})
 		//@InputPortSet(description = "Optional input ports", optional = true, windowingMode = WindowMode.NonWindowed, windowPunctuationInputMode = WindowPunctuationInputMode.Oblivious) })
 @OutputPorts({
 		@OutputPortSet(description = "Request from web to process.", cardinality = 1, optional = false, windowPunctuationOutputMode = WindowPunctuationOutputMode.Generating) })


### PR DESCRIPTION
The input port receiving the response to be sent back to the request is a control port in that it will not submit tuples on the operator's output port as a result of receiving a tuple.

This stops the warning from the SPL compiler of a loop in the graph.

@siegenth 