### PR TITLE
Added funcionality to pass a .jks file to the HTTPPost operator

### DIFF
--- a/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPRequest.java
+++ b/com.ibm.streamsx.inet/impl/java/src/com/ibm/streamsx/inet/http/HTTPRequest.java
@@ -6,7 +6,14 @@
 //
 package com.ibm.streamsx.inet.http;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.charset.Charset;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +53,10 @@ class HTTPRequest {
 	private HttpUriRequest req = null;
 	private HttpEntity entity = null;
 	private double connectionTimeout = 20.0;
-        private HttpParams httpParams = null;
+	private HttpParams httpParams = null;
+    
+	private KeyStore keyStore = null;
+	private String keyStorePassword;
 
 	public HTTPRequest(String url) {
 		this.url =  url;
@@ -82,7 +92,18 @@ class HTTPRequest {
 	
 	public void setConnectionTimeout(double connectionTimeout) {
 		this.connectionTimeout = connectionTimeout;
-	}	
+	}
+	
+	public void initializeKeyStore(String file, String password) throws FileNotFoundException, IOException, NoSuchAlgorithmException, CertificateException, KeyStoreException
+	{
+		keyStorePassword = password;
+		
+		keyStore = KeyStore.getInstance("JKS");
+		
+		try (FileInputStream fis = new FileInputStream(file)) {
+	        keyStore.load(fis,password.toCharArray());
+	    }
+	}
 
 	/**
 	 * Set the parameters for a POST request
@@ -120,10 +141,16 @@ class HTTPRequest {
 	public HTTPResponse sendRequest(IAuthenticate auth) throws Exception {
 		HttpClient client;
 		if(insecure) {
-			client = HTTPUtils.getHttpClientWithNoSSLValidation();
+			if(keyStore == null)
+				client = HTTPUtils.getHttpClientWithNoSSLValidation();
+			else
+				client = HTTPUtils.getHttpClientWithNoSSLServerValidation(keyStore, keyStorePassword);
 		}
 		else {
-			client = new DefaultHttpClient();
+			if(keyStore == null)
+				client = new DefaultHttpClient();
+			else
+				client = HTTPUtils.getHttpClientWithCustomSSlValidation(keyStore, keyStorePassword);
 		}
 		
 		if(method == HTTPMethod.GET) {


### PR DESCRIPTION
### Motivation
When trying to use the HTTPPost operator to use a rest service with a self signed certificate and a private key for the client I had the issue that there was no way to pass these certificate/keys to the operator.

I hope this new functionality is something you would like to merge into the project. I'm open to all suggestions to get the code up to the standards required by the project.

### Features
The operator has two new attributes: keyStoreFile and keyStorePassword.

keyStore file takes the file path to a .jks file that contains all the certificates and keys. keyStorePassword is the password to the .jks file and all the keys in it. I have not implemented different passwords for individual keys.

If you just want to use the private keys in the .jks file and skip checking the certificates you can use the existing acceptAllCertificates attribute.